### PR TITLE
Next.js static files not included in GitHub Pages when deployed

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "next lint",
     "postinstall": "husky",
     "predeploy": "yarn build",
-    "deploy": "gh-pages -d out"
+    "deploy": "gh-pages -d out --nojekyll"
   },
   "dependencies": {
     "@mirohq/miro-api": "^2.0.0",


### PR DESCRIPTION
**What?**

- added `--nojekyll` option to disable Jekyll processing so that the `_next` folder will be kept during deployment