### PR TITLE
Env variables not read in GitHub workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,3 +33,5 @@ jobs:
           yarn deploy -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_PUBLIC_LINK_GITHUB: ${{ env.NEXT_PUBLIC_LINK_GITHUB }}
+          NEXT_PUBLIC_LINK_INSTALL: ${{ env.NEXT_PUBLIC_LINK_INSTALL }}


### PR DESCRIPTION
**What?**

- added env variable explicitly in the `deploy-pages` workflow