### PR TITLE
Env variables not read in GitHub workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,10 @@ name: Deploy to GitHub Pages
 on:
   workflow_dispatch:
 
+env:
+  NEXT_PUBLIC_LINK_GITHUB: ${{ vars.NEXT_PUBLIC_LINK_GITHUB }}
+  NEXT_PUBLIC_LINK_INSTALL: ${{ vars.NEXT_PUBLIC_LINK_INSTALL }}
+
 jobs:
   deploy:
     environment: production
@@ -33,5 +37,3 @@ jobs:
           yarn deploy -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_PUBLIC_LINK_GITHUB: ${{ env.NEXT_PUBLIC_LINK_GITHUB }}
-          NEXT_PUBLIC_LINK_INSTALL: ${{ env.NEXT_PUBLIC_LINK_INSTALL }}


### PR DESCRIPTION
**What?**

- read the env variables from `vars` context as mentioned in the [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-vars-context)